### PR TITLE
Feature/#9 리프레시 토큰 개발

### DIFF
--- a/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/config/PermitAllPaths.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/config/PermitAllPaths.java
@@ -1,0 +1,17 @@
+package com.ssafy.ssashinsa.heyfy.authentication.config;
+
+import java.util.List;
+public class PermitAllPaths {
+    // 인증 필요 없는 url 패턴 리스트  :  application.yml 등에 데이터 저장하는 방법도 있으나, 관리가 힘들어지므로 현재 방식 저장. 후에 상의하여 결정 예정
+    public static final List<String> PATHS = List.of(
+            "/auth/signup/**",
+            "/auth/signin/**",
+            "/auth/refresh/**",
+            "/auth/token/access",
+            "/api/test/public",
+            "/css/**",
+            "/js/**",
+            "/images/**",
+            "/webjars/**"
+    );
+}

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/config/SecurityConfig.java
@@ -20,13 +20,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
-
     @Bean
     public SecurityFilterChain filterChain(
             HttpSecurity http,
             JwtTokenProvider jwtTokenProvider,
             UserDetailsService userDetailsService,
-            CustomAuthenticationEntryPoint customAuthenticationEntryPoint // 이 부분을 추가
+            CustomAuthenticationEntryPoint customAuthenticationEntryPoint
     ) throws Exception {
 
         JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService);
@@ -38,16 +37,11 @@ public class SecurityConfig {
                 )
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/error").permitAll()
-                        .requestMatchers("/auth/signup/**").permitAll()
-                        .requestMatchers("/auth/signin/**").permitAll()
-                        .requestMatchers("/auth/token/access").permitAll()
-                        .requestMatchers("/api/test/public").permitAll()
-                        .requestMatchers("/css/**", "/js/**", "/images/**", "/webjars/**").permitAll()
+                        .requestMatchers(PermitAllPaths.PATHS.toArray(new String[0])).permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(authenticationManager -> authenticationManager
-                        .authenticationEntryPoint(customAuthenticationEntryPoint) // 이 부분을 수정
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/controller/AuthController.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/controller/AuthController.java
@@ -2,13 +2,11 @@ package com.ssafy.ssashinsa.heyfy.authentication.controller;
 
 import com.ssafy.ssashinsa.heyfy.authentication.dto.SignInDto;
 import com.ssafy.ssashinsa.heyfy.authentication.dto.SignInSuccessDto;
+import com.ssafy.ssashinsa.heyfy.authentication.dto.TokenDto;
 import com.ssafy.ssashinsa.heyfy.authentication.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/auth")
@@ -20,5 +18,11 @@ public class AuthController {
     @PostMapping("/signin")
     public ResponseEntity<SignInSuccessDto> signIn(@RequestBody SignInDto signInDto) {
         return ResponseEntity.ok(authService.signIn(signInDto));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenDto> refreshAccessToken(@RequestHeader("Authorization") String authorizationHeader, @RequestHeader("RefreshToken") String refreshToken) {
+        System.out.println("요청 받음");
+        return ResponseEntity.ok(authService.refreshAccessToken(authorizationHeader, refreshToken));
     }
 }

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/dto/TokenDto.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/dto/TokenDto.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class SignInSuccessDto {
+public class TokenDto {
     private String accessToken;
     private String refreshToken;
 }

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.ssafy.ssashinsa.heyfy.authentication.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ssafy.ssashinsa.heyfy.authentication.config.PermitAllPaths;
 import com.ssafy.ssashinsa.heyfy.common.CustomException;
 import com.ssafy.ssashinsa.heyfy.common.ErrorCode;
 import com.ssafy.ssashinsa.heyfy.common.ErrorResponse;
@@ -16,6 +17,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -26,6 +28,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserDetailsService userDetailsService;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String requestURI = request.getRequestURI();
+        AntPathMatcher pathMatcher = new AntPathMatcher();
+
+        return PermitAllPaths.PATHS.stream()
+                .anyMatch(pattern -> pathMatcher.match(pattern, requestURI));
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/jwt/JwtTokenProvider.java
@@ -23,6 +23,10 @@ public class JwtTokenProvider {
     @Value("${spring.jwt.access-expiration}")
     private long accessExpiration;
 
+    @Value("${spring.jwt.refresh-expiration}")
+    private long refreshExpiration;
+
+
     public String createAccessToken(Authentication authentication) {
         String username = authentication.getName();
         String roles = authentication.getAuthorities().stream()
@@ -35,6 +39,19 @@ public class JwtTokenProvider {
         return JWT.create()
                 .withSubject(username)
                 .withClaim("roles", roles)
+                .withIssuedAt(now)
+                .withExpiresAt(validity)
+                .sign(Algorithm.HMAC256(secretKey));
+    }
+
+    public String createRefreshToken(Authentication authentication) {
+        String username = authentication.getName();
+
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + refreshExpiration);
+
+        return JWT.create()
+                .withSubject(username)
                 .withIssuedAt(now)
                 .withExpiresAt(validity)
                 .sign(Algorithm.HMAC256(secretKey));
@@ -60,4 +77,6 @@ public class JwtTokenProvider {
             throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN);
         }
     }
+
+
 }

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/jwt/JwtTokenProvider.java
@@ -27,7 +27,7 @@ public class JwtTokenProvider {
     private long refreshExpiration;
 
 
-    public String createAccessToken(Authentication authentication) {
+    public String createAccessToken(Authentication authentication, String jti) {
         String username = authentication.getName();
         String roles = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
@@ -38,13 +38,14 @@ public class JwtTokenProvider {
 
         return JWT.create()
                 .withSubject(username)
-                .withClaim("roles", roles)
+                .withClaim("roles", roles) // 현 기획상으로는 유저, 관리자 계정이 분리되어 있지 않아 roles이 큰 의미는 없음
+                .withClaim("jti", jti)
                 .withIssuedAt(now)
                 .withExpiresAt(validity)
                 .sign(Algorithm.HMAC256(secretKey));
     }
 
-    public String createRefreshToken(Authentication authentication) {
+    public String createRefreshToken(Authentication authentication, String jti) {
         String username = authentication.getName();
 
         Date now = new Date();
@@ -52,6 +53,7 @@ public class JwtTokenProvider {
 
         return JWT.create()
                 .withSubject(username)
+                .withClaim("jti", jti)
                 .withIssuedAt(now)
                 .withExpiresAt(validity)
                 .sign(Algorithm.HMAC256(secretKey));
@@ -74,6 +76,15 @@ public class JwtTokenProvider {
         } catch (com.auth0.jwt.exceptions.TokenExpiredException e) { //만료된 토큰
             throw new CustomException(ErrorCode.EXPIRED_TOKEN);
         } catch (JWTVerificationException e) { //유효하지 않은 토큰
+            throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN);
+        }
+    }
+
+    public String getJtiFromToken(String token) {
+        try {
+            DecodedJWT jwt = JWT.decode(token);
+            return jwt.getClaim("jti").asString();
+        } catch (JWTVerificationException e) {
             throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN);
         }
     }

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/service/AuthService.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/service/AuthService.java
@@ -2,7 +2,9 @@ package com.ssafy.ssashinsa.heyfy.authentication.service;
 
 import com.ssafy.ssashinsa.heyfy.authentication.dto.SignInDto;
 import com.ssafy.ssashinsa.heyfy.authentication.dto.SignInSuccessDto;
+import com.ssafy.ssashinsa.heyfy.authentication.dto.TokenDto;
 import com.ssafy.ssashinsa.heyfy.authentication.jwt.JwtTokenProvider;
+import com.ssafy.ssashinsa.heyfy.authentication.util.RedisUtil;
 import com.ssafy.ssashinsa.heyfy.common.CustomException;
 import com.ssafy.ssashinsa.heyfy.common.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +19,7 @@ import org.springframework.stereotype.Service;
 public class AuthService {
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RedisUtil redisUtil;
 
     public SignInSuccessDto signIn(SignInDto signInDto) {
         try {
@@ -25,10 +28,78 @@ public class AuthService {
 
             Authentication authentication = authenticationManager.authenticate(authenticationToken);
             String accessToken = jwtTokenProvider.createAccessToken(authentication);
-            return new SignInSuccessDto(accessToken);
+            String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
+
+            redisUtil.deleteRefreshToken(signInDto.getUsername());
+            redisUtil.setRefreshToken(signInDto.getUsername(), refreshToken);
+
+            return new SignInSuccessDto(accessToken, refreshToken);
         } catch (BadCredentialsException e) {
             throw new CustomException(ErrorCode.LOGIN_FAILED);
         }
     }
+
+    public TokenDto refreshAccessToken(String authorizationHeader, String refreshToken) {
+        // 1. RefreshToken 유효성 검증
+        validateRefreshToken(refreshToken);
+        String refreshTokenUsername = jwtTokenProvider.getUsernameFromToken(refreshToken);
+
+        validateAccessTokenAndUserMatch(authorizationHeader, refreshTokenUsername);
+
+        validateRefreshTokenInRedis(refreshTokenUsername, refreshToken);
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(refreshTokenUsername, null, null);
+        String newAccessToken = jwtTokenProvider.createAccessToken(authentication);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(authentication);
+
+        redisUtil.deleteRefreshToken(refreshTokenUsername);
+        redisUtil.setRefreshToken(refreshTokenUsername, newRefreshToken);
+
+        return new TokenDto(newAccessToken, newRefreshToken);
+    }
+
+    private void validateRefreshToken(String refreshToken) {
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            throw new CustomException(ErrorCode.MISSING_REFRESH_TOKEN);
+        }
+        try {
+            jwtTokenProvider.validateToken(refreshToken);
+        } catch (CustomException e) {
+            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+    }
+
+    private void validateAccessTokenAndUserMatch(String authorizationHeader, String refreshTokenUsername) {
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            throw new CustomException(ErrorCode.MISSING_ACCESS_TOKEN);
+        }
+        String accessToken = authorizationHeader.substring(7);
+        try {
+            jwtTokenProvider.validateToken(accessToken);
+            // 보안 강화: 유효한 Access Token으로 갱신 요청 시 Refresh Token 무효화
+            redisUtil.deleteRefreshToken(refreshTokenUsername);
+            throw new CustomException(ErrorCode.NOT_EXPIRED_TOKEN);
+        } catch (CustomException e) {
+            if (!e.getErrorCode().equals(ErrorCode.EXPIRED_TOKEN)) {
+                throw e;
+            }
+            String accessTokenUsername = jwtTokenProvider.getUsernameFromToken(accessToken);
+            if (!accessTokenUsername.equals(refreshTokenUsername)) {
+                throw new CustomException(ErrorCode.UNAUTHORIZED);
+            }
+        }
+    }
+
+    private void validateRefreshTokenInRedis(String refreshTokenUsername, String refreshToken) {
+        String redisRefreshToken = redisUtil.getRefreshToken(refreshTokenUsername);
+        if (redisRefreshToken == null || !redisRefreshToken.equals(refreshToken)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+    }
+
+
+
+
+
 
 }

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/service/CustomUserDetailsService.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/service/CustomUserDetailsService.java
@@ -22,7 +22,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         // 현재 db가 없어 하드코딩으로 user : user, password : ssafy로 설정. 후에 변경할 예정
         if (!"user".equals(username)) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
+            throw new CustomException(ErrorCode.LOGIN_FAILED);
         }
 
         String encodedPassword = passwordEncoder.encode("ssafy");

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/common/ErrorCode.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/common/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 틀립니다."),
 
 
+    TOKEN_PAIR_MISMATCH(HttpStatus.BAD_REQUEST, "액세스 토큰과 리프레쉬 토큰이 매치되지 않습니다"),
     MISSING_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "액세스 토큰이 포함되지 않았습니다."),
     MISSING_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "리프레쉬 토큰이 포함되지 않았습니다"),
     NOT_EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "만료되지 않은 액세스 토큰입니다");

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/common/ErrorCode.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/common/ErrorCode.java
@@ -10,9 +10,15 @@ public enum ErrorCode {
     INVALID_FIELD(HttpStatus.BAD_REQUEST, "잘못된 필드입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"인증되지 않은 사용자입니다"),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레쉬 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),
     INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "유효하지 않은 서명입니다."),
-    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 틀립니다.");
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 틀립니다."),
+
+
+    MISSING_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "액세스 토큰이 포함되지 않았습니다."),
+    MISSING_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "리프레쉬 토큰이 포함되지 않았습니다"),
+    NOT_EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "만료되지 않은 액세스 토큰입니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/common/ErrorResponse.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/common/ErrorResponse.java
@@ -6,22 +6,22 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.http.ResponseEntity;
 
-import java.time.LocalDateTime;
-
 @Getter
 @Setter
 @Builder
 @AllArgsConstructor
 public class ErrorResponse {
     private final int status;
-    private final String error;
+    private final String httpError;
+    private final String errorCode;
     private final String message;
     public static ResponseEntity<ErrorResponse> responseEntity(ErrorCode errorCode) {
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(ErrorResponse.builder()
                         .status(errorCode.getHttpStatus().value())
-                        .error(errorCode.getHttpStatus().name())
+                        .httpError(errorCode.getHttpStatus().name())
+                        .errorCode(errorCode.name())
                         .message(errorCode.getMessage())
                         .build()
                 );
@@ -31,7 +31,8 @@ public class ErrorResponse {
                 .status(errorCode.getHttpStatus())
                 .body(ErrorResponse.builder()
                         .status(errorCode.getHttpStatus().value())
-                        .error(errorCode.getHttpStatus().name())
+                        .httpError(errorCode.getHttpStatus().name())
+                        .errorCode(errorCode.name())
                         .message(message)
                         .build()
                 );

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,10 +3,14 @@ spring:
     name: heyfy
   profiles:
     active: default
+  data:
+    redis:
+      host: localhost
+      port: 6379 # 도커 등 사용시 변경 필요할 수 있음
 
   jwt:
     secret: c6f1a8e2b7d4c90e5f3b2a8d7e6c1a5b9d3f8e0c4b6a7d8e9f2a4c1b5d3a7e9c # 이 파일은 테스트 용이므로, 일단 임의의 비밀 키를 사용
-    access-expiration: 3600000 # 1시간 - 테스트 용으로 길게 잠은 것이므로, 후에 30분가량으로 줄여도 된다
+    access-expiration: 3600000 # 1시간 - 테스트 용으로 길게 잡은 것이므로, 후에 30분가량으로 줄여도 된다
     refresh-expiration: 604800000 # 7일
 
 springdoc:


### PR DESCRIPTION
## 📌 PR 유형
<!-- 해당되는 항목에 체크 -->
- [x] ✨ Feature (기능 추가)
- [x] 🐛 Bug Fix (버그 수정)
- [x] 🔨 Refactor (코드 개선)

---

## 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈 번호 작성 -->
- close #9

---

## 📄 변경 내용
<!-- 핵심 변경 사항 간단히 요약 -->
- Redis를 활용한 서버측 토큰 제어: 리프레시 토큰을 Redis에 저장하여 관리할 수 있도록 했습니다.
- Refresh Token 보안 강화 : 액세스 토큰 갱신 요청이 성공하면 기존의 리프레시 토큰은 무효화(Redis에서 삭제)하고, 새로운 리프레시 토큰을 발급하여 보안을 강화했습니다.
- 토큰 탈취 방어: 만약 유효한 액세스 토큰을 가지고 갱신을 시도하는 비정상적인 요청이 들어오면, 해당 사용자의 RefreshToken을 즉시 무효화하여 탈취된 토큰의 재사용을 막습니다. (해당 사항의 경우 개발기간 중에는 주석처리 해놓을지 합의 필요)
- 사용자 일치 확인: 액세스 토큰과 리프레시 토큰에 포함된 사용자 이름이 동일한지 확인하여 토큰의 오용을 방지합니다.
- PermitAllPaths 클래스 분리 : 코드의 유지보수성을 높이기 위해 PermitAllPaths 클래스를 별도로 분리했습니다. 이 클래스는 인증이 필요 없는 API 경로들을 한 곳에서 관리하는 역할을 하며, SecurityConfig와 JwtAuthenticationFilter에 동일한 경로 목록을 중복해서 정의하는 사태를 방지합니다. (후에 application.yml 등으로 변경 가능합니다)
- 필터 동작 개선: 기존에는 permitAll()로 설정된 페이지라도 JWT 토큰이 포함된 요청에 토큰이 유효하지 않으면 에러가 발생했습니다. 이제는 JwtAuthenticationFilter가 토큰의 유효성을 검사하되, permitAll() 경로에 대한 요청은 토큰 유효성 검정 실패 시에도 에러를 발생시키지 않고 통과시키도록 로직을 수정했습니다.

---

## 🧪 테스트
<!-- 테스트 방법과 결과 -->
- [ ] 로컬 빌드 및 실행 확인
- [ ] 단위 테스트/통합 테스트 통과

---

## ⚠️ 기타 참고 사항
<!-- 리뷰 시 유의할 점, 추가로 논의할 내용 -->
- 
