### PR TITLE
#114: ShinhanExchangeApiClient 내 외화계좌금액조회 uri 수정

### DIFF
--- a/src/main/java/com/ssafy/ssashinsa/heyfy/exchange/service/ExchangeService.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/exchange/service/ExchangeService.java
@@ -62,6 +62,7 @@ public class ExchangeService {
                 .accountNo(foreignAccount.getAccountNo())
                 .accountBalance(Integer.parseInt(response.getREC().getAccountBalance()))
                 .currency(response.getREC().getCurrency())
+                .isForeign(true)
                 .build();
     }
 

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/exchange/util/ShinhanExchangeApiClient.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/exchange/util/ShinhanExchangeApiClient.java
@@ -97,7 +97,7 @@ public class ShinhanExchangeApiClient {
         logRequest(requestDto);
         ShinhanInquireDemandDepositAccountBalanceResponseDto response = apiClient.getClient("edu")
                 .post()
-                .uri("/demandDeposit/inquireForeignCurrencyDemandDepositAccountBalance")
+                .uri("/demandDeposit/foreignCurrency/inquireForeignCurrencyDemandDepositAccountBalance")
                 .header("Content-Type", "application/json")
                 .bodyValue(requestDto)
                 .retrieve()


### PR DESCRIPTION
/demandDeposit/inquireForeignCurrencyDemandDepositAccountBalance
 to /demandDeposit/foreignCurrency/inquireForeignCurrencyDemandDepositAccountBalance

## 📌 PR 유형
<!-- 해당되는 항목에 체크 -->
- [ ] ✨ Feature (기능 추가)
- [x] 🐛 Bug Fix (버그 수정)
- [ ] 🔨 Refactor (코드 개선)

---

## 🔗 관련 이슈
- close #114

---

## 📄 변경 내용
- 신한 외화계좌금액조회 uri 수정
   - 기존 : `/demandDeposit/inquireForeignCurrencyDemandDepositAccountBalance`
   - 변경: `/demandDeposit/foreignCurrency/inquireForeignCurrencyDemandDepositAccountBalance`
