### PR TITLE
2차 인증 기능 구현

### DIFF
--- a/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/controller/AuthController.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.ssafy.ssashinsa.heyfy.authentication.docs.AuthRefreshDocs;
 import com.ssafy.ssashinsa.heyfy.authentication.docs.AuthSignInDocs;
 import com.ssafy.ssashinsa.heyfy.authentication.docs.AuthSignUpDocs;
 import com.ssafy.ssashinsa.heyfy.authentication.dto.*;
+import com.ssafy.ssashinsa.heyfy.authentication.dto.test.MessageDto;
 import com.ssafy.ssashinsa.heyfy.authentication.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,21 @@ public class AuthController {
     @PostMapping("/refresh")
     public ResponseEntity<TokenDto> refreshAccessToken(@RequestHeader("Authorization") String authorizationHeader, @RequestHeader("RefreshToken") String refreshToken) {
         return ResponseEntity.ok(authService.refreshAccessToken(authorizationHeader, refreshToken));
+    }
+
+    @PostMapping("/txntoken")
+    public ResponseEntity<TxnAuthTokenDto> issueTxnAuthToken() {
+        String token = authService.createTxnAuthToken();
+        return ResponseEntity.ok(new TxnAuthTokenDto(token));
+    }
+
+    @PostMapping("/verifypin")
+    public ResponseEntity<MessageDto> verifyPinAndTxnToken(
+                                                            @RequestHeader("TxnAuthToken") String txnAuthToken,
+                                                            @RequestBody TxnAuthRequestDto requestDto
+    ) {
+        authService.verifySecondaryAuth(requestDto.getPinNumber(), txnAuthToken);
+        return ResponseEntity.ok(new MessageDto("2차 인증이 성공적으로 완료되었습니다."));
     }
 
 }

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/dto/SignUpDto.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/dto/SignUpDto.java
@@ -16,6 +16,11 @@ public class SignUpDto {
     private String password;
     @NotBlank
     private String name;
+
+    @NotBlank
+    @Pattern(regexp = "^[0-9]{6}$", message = "PIN은 숫자 6자리여야 합니다.")
+    private String pinNumber;
+
     private String email;
     private String language;
     private String univName;

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/dto/TxnAuthRequestDto.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/dto/TxnAuthRequestDto.java
@@ -1,0 +1,10 @@
+package com.ssafy.ssashinsa.heyfy.authentication.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TxnAuthRequestDto {
+    private String pinNumber;
+}

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/dto/TxnAuthTokenDto.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/dto/TxnAuthTokenDto.java
@@ -1,0 +1,14 @@
+package com.ssafy.ssashinsa.heyfy.authentication.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TxnAuthTokenDto {
+    private String token;
+}

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/exception/AuthErrorCode.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/exception/AuthErrorCode.java
@@ -23,7 +23,11 @@ public enum AuthErrorCode implements ErrorCode {
     EXIST_USER_NAME(HttpStatus.BAD_REQUEST, "이미 존재하는 유저 아이디입니다"),
     EXIST_EMAIL(HttpStatus.BAD_REQUEST,"이미 존재하는 이메일입니다" ),
     INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "비밀번호 형식이 맞지 않습니다."),
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "사용자를 찾을 수 없습니다."),;
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "사용자를 찾을 수 없습니다."), 
+    MISSING_TXN_AUTH_TOKEN(HttpStatus.BAD_REQUEST, "거래 인증 토큰이 포함되지 않았습니다."),
+    EXPIRED_TXN_AUTH_TOKEN(HttpStatus.BAD_REQUEST, "거래 인증이 만료되었습니다."),
+    INVALID_TXN_AUTH_TOKEN(HttpStatus.BAD_REQUEST, "거래 인증 유효하지 않습니다."),
+    INVALID_PIN_NUMBER(HttpStatus.BAD_REQUEST, "2차 비밀번호가 일치하지 않습니다."),;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/authentication/jwt/JwtTokenProvider.java
@@ -12,6 +12,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @Component
@@ -87,6 +88,18 @@ public class JwtTokenProvider {
         } catch (JWTVerificationException e) {
             throw new CustomException(AuthErrorCode.INVALID_ACCESS_TOKEN);
         }
+    }
+
+    public String createTxnAuthToken(String studentId, String jti, long expiration, TimeUnit timeUnit) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + timeUnit.toMillis(expiration));
+
+        return JWT.create()
+                .withSubject(studentId)
+                .withClaim("jti", jti)
+                .withIssuedAt(now)
+                .withExpiresAt(validity)
+                .sign(Algorithm.HMAC256(secretKey));
     }
 
 

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/common/util/RedisUtil.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/common/util/RedisUtil.java
@@ -13,16 +13,31 @@ public class RedisUtil {
     @Value("${spring.jwt.refresh-expiration}")
     private long refreshExpirationMs;
 
+    private static final String REFRESH_TOKEN_PREFIX = "refresh:";
+    private static final String TXN_AUTH_TOKEN_PREFIX = "txnAuth:";
+
     public void setRefreshToken(String key, String value) {
         long timeoutSeconds = refreshExpirationMs / 1000;
-        redisTemplate.opsForValue().set(key, value, timeoutSeconds, java.util.concurrent.TimeUnit.SECONDS);
+        redisTemplate.opsForValue().set(REFRESH_TOKEN_PREFIX + key, value, timeoutSeconds, java.util.concurrent.TimeUnit.SECONDS);
     }
 
     public String getRefreshToken(String key) {
-        return redisTemplate.opsForValue().get(key);
+        return redisTemplate.opsForValue().get(REFRESH_TOKEN_PREFIX + key);
     }
 
     public void deleteRefreshToken(String key) {
-        redisTemplate.delete(key);
+        redisTemplate.delete(REFRESH_TOKEN_PREFIX + key);
+    }
+
+    public void setTxnAuthToken(String key, String value, long expiration, java.util.concurrent.TimeUnit timeUnit) {
+        redisTemplate.opsForValue().set(TXN_AUTH_TOKEN_PREFIX + key, value, expiration, timeUnit);
+    }
+
+    public String getTxnAuthToken(String key) {
+        return redisTemplate.opsForValue().get(TXN_AUTH_TOKEN_PREFIX + key);
+    }
+
+    public void deleteTxnAuthToken(String key) {
+        redisTemplate.delete(TXN_AUTH_TOKEN_PREFIX + key);
     }
 }

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/common/util/TxnAuthTokenUtil.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/common/util/TxnAuthTokenUtil.java
@@ -1,0 +1,57 @@
+package com.ssafy.ssashinsa.heyfy.common.util;
+
+import com.ssafy.ssashinsa.heyfy.authentication.exception.AuthErrorCode;
+import com.ssafy.ssashinsa.heyfy.authentication.jwt.JwtTokenProvider;
+import com.ssafy.ssashinsa.heyfy.common.exception.CustomException;
+import com.ssafy.ssashinsa.heyfy.user.domain.Users;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class TxnAuthTokenUtil {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisUtil redisUtil;
+    private final PasswordEncoder passwordEncoder;
+
+    public String createTxnAuthToken(String studentId) {
+        String jti = UUID.randomUUID().toString();
+        String txnAuthToken = jwtTokenProvider.createTxnAuthToken(studentId, jti, 10L, TimeUnit.MINUTES);
+
+        redisUtil.setTxnAuthToken(studentId, txnAuthToken, 10L, TimeUnit.MINUTES);
+
+        return txnAuthToken;
+    }
+
+    public void verifySecondaryAuth(String studentId, String pinNumber, Users user, String txnAuthToken) {
+        if (txnAuthToken == null || txnAuthToken.isEmpty()) {
+            throw new CustomException(AuthErrorCode.MISSING_TXN_AUTH_TOKEN);
+        }
+
+        try {
+
+            jwtTokenProvider.validateToken(txnAuthToken);
+        } catch (CustomException e) {
+            if (e.getErrorCode().equals(AuthErrorCode.EXPIRED_TOKEN)) {
+                throw new CustomException(AuthErrorCode.EXPIRED_TXN_AUTH_TOKEN);
+            }
+            throw e;
+        }
+
+        String redisToken = redisUtil.getTxnAuthToken(studentId);
+        if (redisToken == null || !redisToken.equals(txnAuthToken)) {
+            throw new CustomException(AuthErrorCode.INVALID_TXN_AUTH_TOKEN);
+        }
+
+        if (!passwordEncoder.matches(pinNumber, user.getPinNumber())) {
+            throw new CustomException(AuthErrorCode.INVALID_PIN_NUMBER);
+        }
+
+        redisUtil.deleteTxnAuthToken(studentId);
+    }
+}

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/user/domain/Users.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/user/domain/Users.java
@@ -1,14 +1,10 @@
 package com.ssafy.ssashinsa.heyfy.user.domain;
 
-import com.github.f4b6a3.ulid.Ulid;
-import com.github.f4b6a3.ulid.UlidCreator;
 import com.ssafy.ssashinsa.heyfy.account.domain.Account;
 import com.ssafy.ssashinsa.heyfy.account.domain.ForeignAccount;
-import com.ssafy.ssashinsa.heyfy.user.ulid.UlidUserType;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.annotations.Type;
 import org.hibernate.type.SqlTypes;
 
 import java.util.UUID;
@@ -24,9 +20,9 @@ import java.util.UUID;
 public class Users {
 
     @Id
-    @Type(UlidUserType.class)
-    @Column(name = "user_id", length = 16)
-    private Ulid id;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
 
     @JdbcTypeCode(SqlTypes.VARCHAR)
     @Column(name = "external_id", unique = true, length = 36)
@@ -66,9 +62,6 @@ public class Users {
 
     @PrePersist
     public void generateIds() {
-        if (this.id == null) {
-            this.id = UlidCreator.getMonotonicUlid();
-        }
         if (this.externalId == null) {
             this.externalId = UUID.randomUUID();
         }

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/user/domain/Users.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/user/domain/Users.java
@@ -44,6 +44,9 @@ public class Users {
     @Column(name = "password", nullable = false)
     private String password;
 
+    @Column(name = "pin_number")
+    private String pinNumber;
+
     @Column(name = "email", unique = true, nullable = false)
     private String email;
 
@@ -52,6 +55,7 @@ public class Users {
 
     @Column(name = "univ_name")
     private String univName;
+
 
 
     @OneToOne(mappedBy = "user", fetch = FetchType.LAZY)

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/user/repository/UserRepository.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/user/repository/UserRepository.java
@@ -1,7 +1,6 @@
 package com.ssafy.ssashinsa.heyfy.user.repository;
 
 
-import com.github.f4b6a3.ulid.Ulid;
 import com.ssafy.ssashinsa.heyfy.account.dto.AccountPairDto;
 import com.ssafy.ssashinsa.heyfy.user.domain.Users;
 import feign.Param;
@@ -10,7 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<Users, Ulid> {
+public interface UserRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByStudentId(String username);
     Optional<Users> findByEmail(String email);
 


### PR DESCRIPTION
## 📌 PR 유형
<!-- 해당되는 항목에 체크 -->
- [ ] ✨ Feature (기능 추가)
- [ ] 🐛 Bug Fix (버그 수정)
- [ ] 🔨 Refactor (코드 개선)

---

## 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈 번호 작성 -->
- close #132 

---

## 📄 변경 내용
<!-- 핵심 변경 사항 간단히 요약 -->
- Users 테이블 변경
    - pk 형식을 uuid에서 long으로 변경
    - pin_number 필드 추가
- redis 기반 2차 인증 기능 구현
- TxnAuthTokenUtil로 2차 인증 구현 기능 모듈화

---

## 🧪 테스트
<!-- 테스트 방법과 결과 -->
- [ ] 로컬 빌드 및 실행 확인
- [ ] 단위 테스트/통합 테스트 통과

---

## ⚠️ 기타 참고 사항
<!-- 리뷰 시 유의할 점, 추가로 논의할 내용 -->
- 현재 AuthController에 테스트 코드를 올려놓긴 했으나, 주요 로직은 TxnAuthTokenUtil에 있고, 문제 발생 시 throw로 커스텀 에러를 리턴하므로 try-catch등을 사용하여 다른 로직에서 활용하세요
- Users 테이블이 변경되었으므로, create 등을 통해 기존 db를 아예 삭제하고 다시 만드는게 편할 겁니다
