### PR TITLE
#136 : HTTP/HTTPS 동시 지원 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,3 +237,5 @@ gradle-app.setting
 **/application-secret.yml
 **/application.yml
 **/application-local.yml
+
+*.p12

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/common/config/WebConfig.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/common/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.ssafy.ssashinsa.heyfy.common.config;
+
+import org.apache.catalina.connector.Connector;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class WebConfig implements WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
+    @Override
+    public void customize(TomcatServletWebServerFactory factory) {
+        factory.addAdditionalTomcatConnectors(createHttpConnector());
+    }
+
+    private Connector createHttpConnector() {
+        Connector connector = new Connector("org.apache.coyote.http11.Http11NioProtocol");
+        connector.setScheme("http");
+        connector.setPort(8080);
+        connector.setSecure(false);
+        return connector;
+    }
+}


### PR DESCRIPTION
## 📌 PR 유형
<!-- 해당되는 항목에 체크 -->
- [x] ✨ Feature (기능 추가)
- [ ] 🐛 Bug Fix (버그 수정)
- [ ] 🔨 Refactor (코드 개선)

---

## 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈 번호 작성 -->
- close #132

---

## 📄 변경 내용
<!-- 핵심 변경 사항 간단히 요약 -->
- WebConfig를 사용하여 API 서버가 HTTP/HTTPS 요청을 동시에 처리하도록 구현

---

## 🧪 테스트
<!-- 테스트 방법과 결과 -->
- [x] 로컬 빌드 및 실행 확인
- [ ] 단위 테스트/통합 테스트 통과

---

## ⚠️ 기타 참고 사항
<!-- 리뷰 시 유의할 점, 추가로 논의할 내용 -->
- 현재 개발 편의성을 위해 HTTP/HTTPS가 동시 지원되도록 구현했습니다. 차후 개발 막바지에 HTTP 연결 시 HTTPS로 자동 리다이렉트되도록 구현할 계획입니다.
- 키스토어 파일 및 서버 설정 같은 민감한 정보는 공개된 페이지가 아닌 별도 경로로 공유하겠습니다.
