### PR TITLE
#186: NotificationScheduler fastApiClient 연동 리팩터

### DIFF
--- a/src/main/java/com/ssafy/ssashinsa/heyfy/fastapi/client/FastApiClient.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/fastapi/client/FastApiClient.java
@@ -1,10 +1,9 @@
 package com.ssafy.ssashinsa.heyfy.fastapi.client;
 
+import com.ssafy.ssashinsa.heyfy.common.exception.CommonErrorCode;
+import com.ssafy.ssashinsa.heyfy.common.exception.CustomException;
 import com.ssafy.ssashinsa.heyfy.fastapi.config.FastApiProperties;
-import com.ssafy.ssashinsa.heyfy.fastapi.dto.FastApiPredictionSummaryResponseDto;
-import com.ssafy.ssashinsa.heyfy.fastapi.dto.FastApiRateAnalysisDto;
-import com.ssafy.ssashinsa.heyfy.fastapi.dto.FastApiRateGraphDto;
-import com.ssafy.ssashinsa.heyfy.fastapi.dto.FastApiRealTimeRatesDto;
+import com.ssafy.ssashinsa.heyfy.fastapi.dto.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
@@ -18,8 +17,23 @@ public class FastApiClient {
     private final FastApiProperties fastApiProperties;
     private final WebClient.Builder webClientBuilder;
 
+    public FastApiRateStatusResponseDto getRateStatus(){
+        FastApiRateStatusResponseDto response = getClient()
+                .get()
+                .uri("/push/rate-status")
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, r ->
+                        r.bodyToMono(String.class).flatMap(body -> {
+                            log.error("API Error Body: {}", body);
+                            throw new CustomException(CommonErrorCode.INTERNAL_SERVER_ERROR, "Failed to fetch from FastAPI.");
+                        }))
+                .bodyToMono(FastApiRateStatusResponseDto.class)
+                .doOnNext(this::logResponse)
+                .block();
+        return response;
+    }
+
     public FastApiRealTimeRatesDto getRealTimeRates(){
-        log.debug("Fetching real-time rates from FastAPI at {}", fastApiProperties.getFullBaseUrl());
         FastApiRealTimeRatesDto response = getClient()
                 .get()
                 .uri("/realtime-rates")
@@ -27,14 +41,11 @@ public class FastApiClient {
                 .onStatus(HttpStatusCode::isError, r ->
                         r.bodyToMono(String.class).flatMap(body -> {
                             log.error("API Error Body: {}", body);
-                            throw new IllegalStateException("Failed to fetch real-time rates from FastAPI.");
+                            throw new CustomException(CommonErrorCode.INTERNAL_SERVER_ERROR, "Failed to fetch from FastAPI.");
                         }))
                 .bodyToMono(FastApiRealTimeRatesDto.class)
                 .doOnNext(this::logResponse)
                 .block();
-        if(response==null){
-            throw new IllegalStateException("Failed to fetch real-time rates from FastAPI.");
-        }
         return response;
     }
     public FastApiRateGraphDto getRateGraph(){
@@ -45,7 +56,7 @@ public class FastApiClient {
                 .onStatus(HttpStatusCode::isError, r ->
                         r.bodyToMono(String.class).flatMap(body -> {
                             log.error("API Error Body: {}", body);
-                            throw new IllegalStateException("Failed to fetch rate-graph from FastAPI.");
+                            throw new CustomException(CommonErrorCode.INTERNAL_SERVER_ERROR, "Failed to fetch from FastAPI.");
                         }))
                 .bodyToMono(FastApiRateGraphDto.class)
                 .doOnNext(this::logResponse)
@@ -63,14 +74,11 @@ public class FastApiClient {
                 .onStatus(HttpStatusCode::isError, r ->
                         r.bodyToMono(String.class).flatMap(body -> {
                             log.error("API Error Body: {}", body);
-                            throw new IllegalStateException("Failed to fetch rate-analysis from FastAPI.");
+                            throw new CustomException(CommonErrorCode.INTERNAL_SERVER_ERROR, "Failed to fetch from FastAPI.");
                         }))
                 .bodyToMono(FastApiRateAnalysisDto.class)
                 .doOnNext(this::logResponse)
                 .block();
-        if(response==null){
-            throw new IllegalStateException("Failed to fetch rate-analysis from FastAPI.");
-        }
         return response;
     }
 
@@ -82,14 +90,11 @@ public class FastApiClient {
                 .onStatus(HttpStatusCode::isError, r ->
                         r.bodyToMono(String.class).flatMap(body -> {
                             log.error("API Error Body: {}", body);
-                            throw new IllegalStateException("Failed to fetch rate prediction summary from FastAPI.");
+                            throw new CustomException(CommonErrorCode.INTERNAL_SERVER_ERROR, "Failed to fetch from FastAPI.");
                         }))
                 .bodyToMono(FastApiPredictionSummaryResponseDto.class)
                 .doOnNext(this::logResponse)
                 .block();
-        if(response==null){
-            throw new IllegalStateException("Failed to fetch rate prediction summary from FastAPI.");
-        }
         return response;
     }
 

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/fastapi/dto/FastApiRateStatusResponseDto.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/fastapi/dto/FastApiRateStatusResponseDto.java
@@ -1,0 +1,19 @@
+package com.ssafy.ssashinsa.heyfy.fastapi.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+
+public class FastApiRateStatusResponseDto {
+    private String normal;
+    private String message;
+}

--- a/src/main/java/com/ssafy/ssashinsa/heyfy/fcm/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/ssafy/ssashinsa/heyfy/fcm/scheduler/NotificationScheduler.java
@@ -1,14 +1,13 @@
 package com.ssafy.ssashinsa.heyfy.fcm.scheduler;
 
-import com.ssafy.ssashinsa.heyfy.fcm.dto.ExchangeRateResponse;
+import com.ssafy.ssashinsa.heyfy.fastapi.client.FastApiClient;
+import com.ssafy.ssashinsa.heyfy.fastapi.dto.FastApiRateStatusResponseDto;
 import com.ssafy.ssashinsa.heyfy.fcm.repository.FcmTokenRepository;
 import com.ssafy.ssashinsa.heyfy.fcm.service.FcmService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
-import java.util.List;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 
 @Slf4j
 @Service
@@ -17,28 +16,18 @@ public class NotificationScheduler {
 
     private final FcmTokenRepository fcmTokenRepository;
     private final FcmService fcmService;
-    private final RestTemplate restTemplate;
+    private final FastApiClient fastApiClient;
 
     @Scheduled(cron = "0 0 7 * * *", zone = "Asia/Seoul")
     public void sendDailyExchangeRateNotification() {
         log.info("스케줄러 실행: 환율 정보를 가져와 모든 사용자에게 알림을 보냅니다.");
+        FastApiRateStatusResponseDto response = fastApiClient.getRateStatus();
+        if (response != null && response.getMessage() != null && !response.getMessage().isEmpty()) {
+            String title = "Today's Exchange Rate Information";
+            String body = response.getMessage();
 
-        try {
-            String apiUrl = "http://114.199.133.118:8888/api/push/rate-status";
-            ExchangeRateResponse response = restTemplate.getForObject(apiUrl, ExchangeRateResponse.class);
-
-            log.info("API 응답: {}", response);
-            if (response != null && response.getMessage() != null && !response.getMessage().isEmpty()) {
-                String title = "Today's Exchange Rate Information";
-                String body = response.getMessage();
-
-                fcmService.sendNotificationToAll(title, body);
-            } else {
-                log.warn("API로부터 유효한 메시지를 받지 못했습니다.");
-            }
-
-        } catch (Exception e) {
-            log.error("외부 API 호출 또는 알림 발송 중 오류가 발생했습니다.", e);
+            fcmService.sendNotificationToAll(title, body);
         }
+
     }
 }

--- a/src/test/java/com/ssafy/ssashinsa/heyfy/fastapi/FastApiClientTest.java
+++ b/src/test/java/com/ssafy/ssashinsa/heyfy/fastapi/FastApiClientTest.java
@@ -56,4 +56,15 @@ class FastApiClientTest {
             System.out.println("getRateAnalysis error: " + e.getMessage());
         }
     }
+
+    @Test
+    @DisplayName("FastApiClient 환율 분석 API 실행 테스트")
+    void getPushRateStatus() {
+        try {
+            var result = fastApiClient.getRateStatus();
+            System.out.println("getRateAnalysis result: " + result);
+        } catch (Exception e) {
+            System.out.println("getRateAnalysis error: " + e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
## 📌 PR 유형
<!-- 해당되는 항목에 체크 -->
- [ ] ✨ Feature (기능 추가)
- [ ] 🐛 Bug Fix (버그 수정)
- [x] 🔨 Refactor (코드 개선)

---

## 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈 번호 작성 -->
- close #186 

---

## 📄 변경 내용
<!-- 핵심 변경 사항 간단히 요약 -->
- FastApiClient 내 /push/rate-status 요청 메서드 추가
- NotificationScheduler 내 RestTemplate 대신 FastApiClient 메서드 사용하도록 변경

---

## 🧪 테스트
<!-- 테스트 방법과 결과 -->
- [x] 로컬 빌드 및 실행 확인
- [x] 단위 테스트/통합 테스트 통과

---

## ⚠️ 기타 참고 사항
<!-- 리뷰 시 유의할 점, 추가로 논의할 내용 -->
- RestTemplate에 비해 WebClient가 가지는 이점때문에 WebClient 방식으로 통일하겠습니다.
   - 의존성 감소
   - 비동기 처리 가능
   - 예외처리 로직 간소화
